### PR TITLE
update how timestamp handled upon edit or delete

### DIFF
--- a/sql/messages.sql
+++ b/sql/messages.sql
@@ -13,5 +13,6 @@ CREATE TABLE IF NOT EXISTS messages
     comment_count integer,
     deleted boolean,
     uuid character varying NOT NULL,
-    created timestamp with time zone NOT NULL
+    created timestamp with time zone NOT NULL,
+    last_edited timestamp with time zone
 );


### PR DESCRIPTION
Used proper time type in Go.

Updates new field associated with Message content type 'last_edited' which will tell us when the post was last edited (updated or deleted). 

Defaults to a non-valid timestamp (like when a message is created)

Example Data: https://gist.github.com/rakazirut/9b64484c7ec0ce860a086e16605463e2

Notice is Message ID 1,2 the lastEdited stamp is real and return Valid : true. This means a post has been edited. Then notice for ID 3 the timestamp isn't real and Valid: false. This means a post has never been edited (i.e it was created and no other valid 'edit' actions occurred)