### PR TITLE
logic for add+remove upvote and downvote requiring account uuid

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -33,16 +33,16 @@ func CreateAccount(c *gin.Context) {
 	}
 
 	addr, err := mail.ParseAddress(strings.ToLower(acc.Email))
-    if err != nil {
-		c.IndentedJSON(http.StatusInternalServerError, gin.H{
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
 			"Error": "Error: Email address format is not valid. Please us a valid email address.",
 		})
 		return
-    }
+	}
 
 	hashedPassword, err := hashPassword(acc.Password)
 	if err != nil {
-		c.IndentedJSON(http.StatusInternalServerError, gin.H{
+		c.JSON(http.StatusBadRequest, gin.H{
 			"Error": "Error: A error occurred creating the account. Please try again.",
 		})
 		return
@@ -57,13 +57,13 @@ func CreateAccount(c *gin.Context) {
 	acc.Created = pq.NullTime{Time: time.Now(), Valid: true}
 
 	if result := db.Db.Create(&acc); result.Error != nil {
-		c.IndentedJSON(http.StatusInternalServerError, gin.H{
-			"Error": result.Error.Error(),
+		c.JSON(http.StatusBadRequest, gin.H{
+			"Error": "Could not create account. Please try again.",
 		})
 		return
 	}
 
-	c.IndentedJSON(http.StatusCreated, acc)
+	c.JSON(http.StatusCreated, acc)
 }
 
 // Hash password

--- a/sql/db.sql
+++ b/sql/db.sql
@@ -68,3 +68,12 @@ CREATE TABLE IF NOT EXISTS comments (
     created timestamp with time zone NOT NULL,
     last_edited timestamp with time zone
 );
+
+CREATE TABLE IF NOT EXISTS content_votes (
+    id SERIAL PRIMARY KEY,
+    upvote boolean,
+    downvote boolean,
+    content_uuid character varying NOT NULL REFERENCES contents(uuid),
+    account_uuid character varying NOT NULL REFERENCES accounts(uuid),
+    last_edited timestamp with time zone NOT NULL
+);


### PR DESCRIPTION
content upvote/down vote routes temporarily require query param `?auuid+{{account_uuid}}` so we can associate the vote with a user without having a auth token