### PR TITLE
add code for token generation and return from login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.15.5 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/pgx/v5 v5.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,10 @@ github.com/go-playground/validator/v10 v10.15.5 h1:LEBecTWb/1j5TNY1YYG2RcOUN3R7N
 github.com/go-playground/validator/v10 v10.15.5/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -52,4 +52,5 @@ func Routes(router *gin.Engine) {
 	// Account
 	router.POST("/account/create", account.CreateAccount)
 	router.POST("/account/login", account.AccountLogin)
+	router.GET("/account/token/validate", account.ValidateAccountToken)
 }

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,50 @@
+package token
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var secretKey = []byte(os.Getenv("TOKEN_SECRET"))
+
+// CreateToken generates a JWT token with the provided username and UUID.
+// The token is signed using the HS256 signing method and contains the following claims:
+// - "username": the username of the account
+// - "accountUuid": the UUID of the account
+// - "exp": the expiration time of the token, set to 24 hours from the current time
+// The function returns the generated token string and an error if any occurred.
+func CreateToken(username string, uuid string) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256,
+		jwt.MapClaims{
+			"username":    username,
+			"accountUuid": uuid,
+			"exp":         time.Now().Add(time.Hour * 24).Unix(),
+		})
+
+	tokenString, err := token.SignedString(secretKey)
+	if err != nil {
+		return "", err
+	}
+	return tokenString, nil
+}
+
+// VerifyToken verifies the validity of a JWT token.
+// It takes a token string as input and returns an error if the token is invalid.
+func VerifyToken(tokenString string) error {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		return secretKey, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if !token.Valid {
+		return fmt.Errorf("invalid token")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Login route returns actual signed token. Returns as cookie (desired) and response body (fallback).

Add route to validate the token. This is purely for testing that we are sending requests from the front end properly, although we will reuse the underlining functionality.